### PR TITLE
add support for 'alias' synonym type

### DIFF
--- a/js/chromosoml/gene_page.js
+++ b/js/chromosoml/gene_page.js
@@ -1682,7 +1682,7 @@ dbxrefs.push({
                     var synonyms = geneInfo.synonyms("synonym", null, true);
                     var product_synonyms = geneInfo.synonyms("product_synonym", null, true);
                     var previous_systematic_ids = geneInfo.synonyms("previous_systematic_id", null, true);
-
+                    var aliases = geneInfo.synonyms("alias", null, true);
 
                     var systematicName = geneInfo.systematic_name();
 

--- a/js/chromosoml/gene_page.js
+++ b/js/chromosoml/gene_page.js
@@ -1714,6 +1714,7 @@ dbxrefs.push({
                         synonyms : synonyms,
                         product_synonyms : product_synonyms,
                         previous_systematic_ids : previous_systematic_ids,
+                        aliases : aliases,
                         len : function(maps) { // returns the combined size of
                             // a list of maps
                             var count = 0

--- a/js/chromosoml/tpl/summary.html
+++ b/js/chromosoml/tpl/summary.html
@@ -20,8 +20,8 @@
 	    <th>Synonym</th>
 		<td data-bind="template: {name: 'synonyms', data: {synonyms:synonyms,separate:separate,name:'synonyms'} }" ></td>
     </tr>
-    <tr data-bind="visible: len([synonyms]) > 0">
-	    <th>Synonym</th>
+    <tr data-bind="visible: len([aliases]) > 0">
+	    <th>Alias</th>
 		<td data-bind="template: {name: 'synonyms', data: {synonyms:aliases,separate:separate,name:'aliases'} }" ></td>
     </tr>
 	<tr>

--- a/js/chromosoml/tpl/summary.html
+++ b/js/chromosoml/tpl/summary.html
@@ -5,8 +5,8 @@
 		  <span data-bind="text: systematicName"></span>
 		  <span data-bind="visible: ntranscripts > 1">
             (one splice form of this gene)</span>
-          
-		  
+
+
 		  <span data-bind="visible: len(previous_systematic_ids) > 0">
             (previously known as : <span data-bind="template: {name: 'synonyms', data: {synonyms:previous_systematic_ids,separate:separate,name:'previous_systematic'} }"></span>)
           </span>
@@ -19,6 +19,10 @@
 	<tr data-bind="visible: len([synonyms]) > 0">
 	    <th>Synonym</th>
 		<td data-bind="template: {name: 'synonyms', data: {synonyms:synonyms,separate:separate,name:'synonyms'} }" ></td>
+    </tr>
+    <tr data-bind="visible: len([synonyms]) > 0">
+	    <th>Synonym</th>
+		<td data-bind="template: {name: 'synonyms', data: {synonyms:aliases,separate:separate,name:'aliases'} }" ></td>
     </tr>
 	<tr>
 		<th>Gene Type</th>


### PR DESCRIPTION
This PR adds support for displaying synonyms of the 'alias' type on gene pages.