### PR TITLE
redirect to quick search on gene page lookup error

### DIFF
--- a/js/chromosoml/gene_page.js
+++ b/js/chromosoml/gene_page.js
@@ -213,14 +213,16 @@ $(function() {
 
                 },
                 error : function(xhr, opts, error) {
-                    self.error_msg = error;
+                    /* self.error_msg = error;
                     self.error_code = xhr.status;
                     $(".spinner").hide();
                     $(".wacontainer").hide();
                     var mtext = $.tmpl("<div class='full-light-grey-top'></div><div class='light-grey'><h2> Error ${error_code}</h2> <div> An error occurred fetching the annotation for ${uniquename}: <i>${error_msg}</i>. </div></div><div class='full-light-grey-bot' ></div>",
                         {"error_msg" : error, "error_code" : xhr.status, "uniquename" : self.uniqueName});
                     mtext.appendTo("#col-2-1");
-                    $("#col-2-1").stop().fadeTo(100, 1);
+                    $("#col-2-1").stop().fadeTo(100, 1); */
+                    var newURL = window.location.protocol + "//" + window.location.host + "/Query/quickSearch?redirect=false&allNames=true&taxons=Root&searchText=" + self.uniqueName;
+                    window.location.replace(newURL);
                 }
             });
         }


### PR DESCRIPTION
This PR introduces a behaviour change in the gene page frontend. Instead of just displaying a noninformative HTTP error message to the user when an error looking up the requested gene is encountered, the user is redirected to the quicksearch results for his request. This will give a user better suggestions for where they might want to go.